### PR TITLE
Enable system and microphone audio capture

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "sck-cli",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v15)
     ],
     products: [
         .executable(name: "sck-cli", targets: ["sck-cli"]) 
@@ -22,7 +22,8 @@ let package = Package(
                 .linkedFramework("CoreVideo"),
                 .linkedFramework("CoreGraphics"),
                 .linkedFramework("CoreMedia"),
-                .linkedFramework("AppKit")
+                .linkedFramework("AppKit"),
+                .linkedFramework("AVFoundation")
             ]
         )
     ]

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.sck-cli</string>
+    <key>CFBundleName</key>
+    <string>sck-cli</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Allows sck-cli to record microphone audio.</string>
+</dict>
+</plist>

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -6,6 +6,7 @@ import Metal
 import CoreMedia
 import CoreVideo
 import Dispatch
+import AVFoundation
 
 @main
 struct SCKShot {
@@ -24,39 +25,85 @@ struct SCKShot {
         cfg.width  = display.width
         cfg.height = display.height
         cfg.pixelFormat = kCVPixelFormatType_32BGRA
+        cfg.capturesAudio = true
+        cfg.captureMicrophone = true
+        cfg.sampleRate = 48_000
+        cfg.channelCount = 2
 
-        // 4) Create stream and a frame receiver
+        // 4) Create stream and a frame/audio receiver
         let stream = SCStream(filter: filter, configuration: cfg, delegate: nil)
 
         final class Output: NSObject, SCStreamOutput {
             let sema = DispatchSemaphore(value: 0)
-            func stream(_ stream: SCStream, didOutputSampleBuffer sb: CMSampleBuffer, of outputType: SCStreamOutputType) {
-                guard outputType == .screen, let imgBuf = sb.imageBuffer else { return }
-                // Write PNG to disk
-                let ci = CIImage(cvImageBuffer: imgBuf)
-                let ctx = CIContext(options: nil)
-                let url = URL(fileURLWithPath: "capture.png")
-                if let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
-                   let data = ctx.pngRepresentation(of: ci, format: .BGRA8, colorSpace: colorSpace) {
-                    try? data.write(to: url)
-                    print("wrote \(url.path)")
+            var screenWritten = false
+            var audioWritten = false
+
+            private let audioWriter: AVAssetWriter
+            private let audioInput: AVAssetWriterInput
+            private var audioSessionStarted = false
+
+            override init() {
+                let audioURL = URL(fileURLWithPath: "audio.m4a")
+                audioWriter = try! AVAssetWriter(url: audioURL, fileType: .m4a)
+                let audioSettings: [String: Any] = [
+                    AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVSampleRateKey: 48_000,
+                    AVNumberOfChannelsKey: 2
+                ]
+                audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+                audioInput.expectsMediaDataInRealTime = true
+                if audioWriter.canAdd(audioInput) {
+                    audioWriter.add(audioInput)
                 }
-                sema.signal()
+                audioWriter.startWriting()
+            }
+
+            func stream(_ stream: SCStream, didOutputSampleBuffer sb: CMSampleBuffer, of outputType: SCStreamOutputType) {
+                switch outputType {
+                case .screen:
+                    guard let imgBuf = sb.imageBuffer else { return }
+                    // Write PNG to disk
+                    let ci = CIImage(cvImageBuffer: imgBuf)
+                    let ctx = CIContext(options: nil)
+                    let url = URL(fileURLWithPath: "capture.png")
+                    if let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+                       let data = ctx.pngRepresentation(of: ci, format: .BGRA8, colorSpace: colorSpace) {
+                        try? data.write(to: url)
+                        print("wrote \(url.path)")
+                    }
+                    screenWritten = true
+                case .audio:
+                    if !audioSessionStarted {
+                        audioWriter.startSession(atSourceTime: CMSampleBufferGetPresentationTimeStamp(sb))
+                        audioSessionStarted = true
+                    }
+                    if audioInput.isReadyForMoreMediaData {
+                        audioInput.append(sb)
+                        audioInput.markAsFinished()
+                        audioWriter.finishWriting {
+                            print("wrote audio.m4a")
+                        }
+                        audioWritten = true
+                    }
+                default:
+                    return
+                }
+                if screenWritten && audioWritten {
+                    sema.signal()
+                }
             }
         }
 
         let out = Output()
         try! stream.addStreamOutput(out, type: .screen, sampleHandlerQueue: .main)
+        try! stream.addStreamOutput(out, type: .audio, sampleHandlerQueue: .main)
 
-        // 5) Start, await one frame, then stop
+        // 5) Start, await one frame and audio sample, then stop
         try? await stream.startCapture()
 
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            out.sema.signal() // no-op if already signaled; keep continuity simple
-            // Resume when first frame handler signals
-            DispatchQueue.main.async {
-                // If a frame already arrived, this will have been signaled
-                _ = out.sema.wait(timeout: .now())
+            DispatchQueue.global().async {
+                out.sema.wait()
                 cont.resume()
             }
         }

--- a/sck-cli.entitlements
+++ b/sck-cli.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- raise minimum macOS to 15 and link AVFoundation
- capture system and microphone audio, writing first buffers to `audio.m4a`
- add microphone privacy string and audio-input entitlement

## Testing
- `swift build` *(fails: no such module 'ScreenCaptureKit')*

------
https://chatgpt.com/codex/tasks/task_e_6899073314dc832f982f8ec4a50cfd4e